### PR TITLE
Allow Workbench Job to launch without 'job_name'

### DIFF
--- a/code/01_Functions_00_launch_workbench_job.R
+++ b/code/01_Functions_00_launch_workbench_job.R
@@ -30,16 +30,18 @@ launch_workbench_job <- function(job_name = NULL, # Name to give the Workbench J
   
   ### ---- Check arguments passed to the function                       ---- ###
   
-  # job_name - should be a string (one element character vector)
-  if(!inherits(job_name, "character")){
-    cli::cli_abort(c(
-      "{.var job_name} must be an object of class {.cls {class('character')}}.",
-      "x" = "{.var job_name} is an object of class {.cls {class(job_name)}}."))
-  } else{
-    if (!length(job_name) == 1){
+  # job_name - should be a string (one element character vector) (if not null)
+  if(!is.null(job_name)){
+    if(!inherits(job_name, "character")){
       cli::cli_abort(c(
-        "{.var job_name} must be a {.cls {class('character')}} vector of length 1.",
-        "x" = paste0("{.var job_name} is a {.cls {class(job_name)}} vector of length ", length(job_name), ".")))
+        "{.var job_name} must be an object of class {.cls {class('character')}}.",
+        "x" = "{.var job_name} is an object of class {.cls {class(job_name)}}."))
+    } else{
+      if (!length(job_name) == 1){
+        cli::cli_abort(c(
+          "{.var job_name} must be a {.cls {class('character')}} vector of length 1.",
+          "x" = paste0("{.var job_name} is a {.cls {class(job_name)}} vector of length ", length(job_name), ".")))
+      }
     }
   }
   

--- a/code/test_launch_workbench_job_without_job_name.R
+++ b/code/test_launch_workbench_job_without_job_name.R
@@ -1,0 +1,21 @@
+################################################################################
+# Name of file:       test_launch_workbench_job_without_job_name.R
+# Type of script:     R
+#
+# Original author:    Terry McLaughlin
+#
+# Written/run on: R version 4.1.2 (2021-11-01) -- "Bird Hippie"
+# Platform: x86_64-pc-linux-gnu (64-bit)
+#
+# Test of function to programmatically launch workbench jobs on the Kubernetes
+# cluster.
+################################################################################
+
+### 00 Launch Workbench Job ----
+
+job_id <- launch_workbench_job(project_path = here::here(),
+                               script = "code/test_launch_workbench_job_script.R")
+
+Sys.sleep(3)
+
+rstudioapi::launcherGetJob(job_id)


### PR DESCRIPTION
Amend 'launch_workbench_job()' function to execute correctly when the argument 'job_name' is not specified.

Includes the R script 'code/test_launch_workbench_job_without_job_name.R' for testing that this works as expected.